### PR TITLE
Namespace static assert redefinitition typedef

### DIFF
--- a/include/tn/error.h
+++ b/include/tn/error.h
@@ -39,7 +39,7 @@
 
 #define TN_CLIENT_ECONN -500
 
-#define TN_STATIC_ASSERT(cond) AWS_STATIC_ASSERT(cond)
+#define TN_STATIC_ASSERT(cond) AWS_STATIC_ASSERT1(cond, AWS_CONCAT(tn_, __LINE__))
 #define TN_ASSERT(expr) assert(expr)
 #define TN_GUARD(expr) \
     if ((expr)) return TN_ERROR


### PR DESCRIPTION
Fixes a compile error where a static assert typedef conflicts with an internal AWS common one, they are both on the same line but in different files.